### PR TITLE
autofocus and submit with an enter at the input 

### DIFF
--- a/views/room.ejs
+++ b/views/room.ejs
@@ -17,10 +17,10 @@
     <div id="container">
         <div id="users-grid"></div>
         <div id="opts-container">
-            <div id="name-selection-div">
-                <input type="text" name="name-input" id="name-input">
+            <form id="name-selection-div">
+                <input type="text" name="name-input" id="name-input" autofocus>
                 <button id="name-submit" onclick="join()">Join</button>
-            </div>
+            </form>
         </div>
     </div>
 </body>


### PR DESCRIPTION
When the page loads, the input field will be already selected, being necessary only typing the name and pressing `enter` to submit

The button is still available though